### PR TITLE
Changed postgresql image version to 'latest'

### DIFF
--- a/openshift/gogs-template.yaml
+++ b/openshift/gogs-template.yaml
@@ -323,7 +323,7 @@ parameters:
   value: 12MB
 - displayName: Database version (PostgreSQL)
   name: DATABASE_VERSION
-  value: "9.5"
+  value: "latest"
 - name: GOGS_VERSION
   displayName: Gogs Version
   description: 'Version of the Gogs container image to be used (check the available version https://hub.docker.com/r/openshiftdemos/gogs/tags)'


### PR DESCRIPTION
postgresql image version 9.5 is no longer available in oc image stream. Hence, no need to worry about updates in the image here onwards :)

$ oc get is -n openshift | grep postgresql
postgresql                               default-route-openshift-image-registry.apps-crc.testing/openshift/postgresql                               10,9.6,latest                                         5 months ago